### PR TITLE
Fix build errors (#14)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ node_js:
 
 after_script:
   - cat coverage/lcov.info | coveralls
+  - npm run build

--- a/src/components/counter.tsx
+++ b/src/components/counter.tsx
@@ -38,7 +38,7 @@ const mapDispatchToProps = (dispatch: redux.Dispatch<Store.All>): ConnectedDispa
   increment: (n: number) =>
     dispatch(incrementCounter(n)),
   load: () =>
-    dispatch(loadCount(null)),
+    dispatch(loadCount()),
   save: (value: number) =>
     dispatch(saveCount({ value })),
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "./dist/",
     "sourceMap": true,
     "noImplicitAny": true,
-    "lib": ["es6"],
+    "lib": ["es6", "dom"],
     "module": "commonjs",
     "target": "es6",
     "jsx": "react"


### PR DESCRIPTION
Fix incompatible method call and restore DOM include (see DefinitelyTyped/DefinitelyTyped#13251) to get the build back to green.

